### PR TITLE
Docker image refinement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=build-stage /app/websites/default/index.html /var/www/html/
 
 EXPOSE 8080
 
-CMD ["/usr/bin/webserv"]
+CMD ["/usr/bin/webserv", "-o", "on"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,6 @@ RUN ln -s /etc/webserv/sites-available/default.conf /etc/webserv/sites-enabled/
 RUN mkdir -p /var/www/html
 COPY --from=build-stage /app/websites/default/index.html /var/www/html/
 
-EXPOSE 8080
+EXPOSE 80
 
 CMD ["/usr/bin/webserv", "-o", "on"]

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ docker.build:
 	docker build -t webserv .
 
 docker.run:
-	docker run --rm -p 8080:8080 --name webserv webserv:latest
+	docker run --rm -p 8080:80 --name webserv webserv:latest
 
 lines:
 	@wc -l $(SRC_DIR)/*.cpp $(INC_DIR)/*.hpp $(SRC_DIR)/*/*.cpp $(INC_DIR)/*/*.hpp | sort 

--- a/conf/sites-available/default.conf
+++ b/conf/sites-available/default.conf
@@ -1,5 +1,5 @@
 server {
-  listen 0.0.0.0:8080;
+  listen 0.0.0.0:80;
 
   root /var/www/html;
 


### PR DESCRIPTION
- Enable terminal output in image cmd
- Use port 80 instead of 8080 internally