### PR TITLE
Fix code scanning alert no. 3: Use of potentially dangerous function

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -157,7 +157,7 @@ std::string percentEncode(std::string str, std::string reserved) {
 }
 
 std::string getTime(std::string format, const time_t* timer) {
-  struct tm* timeinfo;
+  struct tm timeinfo;
   size_t size = 64;
 
   time_t rawtime;
@@ -168,8 +168,8 @@ std::string getTime(std::string format, const time_t* timer) {
   if (endsWith(format, " GMT") == false) format += " GMT";
   while (true) {
     std::string buffer(size, '\0');
-    timeinfo = std::gmtime(timer);
-    size_t ret = std::strftime(&buffer[0], size, format.c_str(), timeinfo);
+    std::gmtime_r(timer, &timeinfo);
+    size_t ret = std::strftime(&buffer[0], size, format.c_str(), &timeinfo);
     if (ret != 0) {
       buffer.resize(ret);
       return buffer;


### PR DESCRIPTION
Fixes [https://github.com/PythonGermany/42_webserv/security/code-scanning/3](https://github.com/PythonGermany/42_webserv/security/code-scanning/3)

To fix the problem, we need to replace the call to `std::gmtime` with `std::gmtime_r`. This change ensures that the `tm` structure is allocated by the caller, making the function call thread-safe. 

- We will modify the `getTime` function to use `std::gmtime_r` instead of `std::gmtime`.
- We will allocate a `tm` structure on the stack and pass its pointer to `std::gmtime_r`.
- This change will be made in the file `src/utils/utils.cpp` at the relevant lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
